### PR TITLE
:recycle: refactor : server_name 과 host 분리 & default_server 명시 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -78,7 +78,9 @@
 		"bit": "cpp",
 		"functional": "cpp",
 		"iterator": "cpp",
-		"utility": "cpp"
+		"utility": "cpp",
+		"numeric": "cpp",
+		"random": "cpp"
 	},
 	"cmake.configureOnOpen": false
 }

--- a/configs/tests/validator/ServerBlock/case_29.config
+++ b/configs/tests/validator/ServerBlock/case_29.config
@@ -1,0 +1,18 @@
+server {
+	listen 8080
+	error energetic.html
+	route / {
+	}
+}
+server {
+	listen 8080
+	server_name ghan
+	route / {
+	}
+}
+server {
+	listen 8081
+	server_name jiskim
+	route / {
+	}
+}

--- a/configs/tests/validator/ServerBlock/case_30.config
+++ b/configs/tests/validator/ServerBlock/case_30.config
@@ -1,0 +1,19 @@
+server {
+	listen 1111
+	server_name z
+	error go.html
+	route / {
+	}
+}
+server {
+	listen 1111
+	server_name b
+	route / {
+	}
+}
+server {
+	listen 1111
+	server_name a
+	route / {
+	}
+}

--- a/includes/Types.hpp
+++ b/includes/Types.hpp
@@ -10,6 +10,11 @@
 #ifndef INCLUDES_TYPES_HPP_
 #define INCLUDES_TYPES_HPP_
 
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
 #define GET 0b00000001
 #define POST 0b00000010
 #define DELETE 0b00000100
@@ -23,7 +28,7 @@ typedef unsigned char uint8_t;
 typedef unsigned short int uint16_t;
 typedef unsigned int uint32_t;
 
-// SECTION : RouteBlock
+// SECTION : Validator 파싱 구조체 typedef
 struct RouteBlock {
   bool autoindex;
   uint8_t methods;
@@ -57,11 +62,9 @@ struct RouteBlock {
   }
 };
 
-// SECTION : Validator 파싱 구조체 typedef
 typedef std::map<std::string, RouteBlock> RouteMap;
 typedef std::pair<std::string, RouteBlock> RouteNode;
 
-// SECTION : ServerBlock
 struct ServerBlock {
   std::string error;
   RouteMap route_map;
@@ -69,17 +72,16 @@ struct ServerBlock {
   ServerBlock(void) : error("error.html") {}
 };
 
-// SECTION : HostVector 의 element
-struct HostPair {
-  uint16_t port;
-  std::string host;
-
-  HostPair(void) : port(0), host("127.0.0.1") {}
-};
-
-// SECTION : Validator 파싱 구조체 typedef
 typedef std::map<std::string, ServerBlock> ServerMap;
 typedef std::pair<std::string, ServerBlock> ServerNode;
-typedef std::vector<HostPair> HostVector;
+
+struct ServerGate {
+  ServerBlock default_server;
+  ServerMap server_map;
+};
+
+typedef std::map<uint16_t, ServerGate> PortMap;
+typedef std::pair<uint16_t, ServerGate> PortNode;
+typedef std::set<uint16_t> PortSet;
 
 #endif  // INCLUDES_TYPES_HPP_

--- a/includes/Validator.hpp
+++ b/includes/Validator.hpp
@@ -13,10 +13,9 @@
 #include <algorithm>
 #include <exception>
 #include <iostream>
-#include <map>
+#include <list>
 #include <sstream>
 #include <string>
-#include <vector>
 
 #include "Types.hpp"
 
@@ -24,16 +23,8 @@
 class Validator {
  public:
   struct Result {
-    ServerMap server_map;
-    HostVector host_vector;
-  };
-
-  struct ResultPair {
-    ServerNode server_node;
-    HostPair host_pair;
-
-    ResultPair(ServerNode server_node, HostPair host_pair)
-        : server_node(server_node), host_pair(host_pair) {}
+    PortMap port_map;
+    PortSet port_set;
   };
 
   Validator(const std::string& config);
@@ -84,6 +75,15 @@ class Validator {
     kParam,
   };
 
+  struct PortServerPair {
+    uint16_t port;
+    ServerNode server_node;
+
+    PortServerPair(uint16_t port, ServerNode server_node)
+        : port(port), server_node(server_node) {}
+  };
+
+  typedef std::list<PortServerPair> PortServerList_;
   typedef std::string::const_iterator ConstIterator_;
   typedef std::map<std::string, ServerDirective> ServerKeyMap_;
   typedef std::map<std::string, ServerDirective>::iterator ServerKeyIt_;
@@ -110,8 +110,8 @@ class Validator {
 
   // 디렉티브별로 파싱하는 switch
   bool SwitchDirectivesToParseParam(ConstIterator_& delim,
-                                    ServerBlock& server_block,
-                                    HostPair& host_pair,
+                                    ServerBlock& server_block, uint16_t& port,
+                                    std::string& server_name,
                                     ServerKeyMap_& key_map);
   bool SwitchDirectivesToParseParam(ConstIterator_& delim,
                                     RouteBlock& route_block,
@@ -119,8 +119,11 @@ class Validator {
                                     ServerDirective is_cgi);
 
   // ServerBlock, RouteBlock 파싱 및 검증
-  ResultPair ValidateServerBlock(void);
+  PortServerPair ValidateServerBlock(PortSet& port_set);
   RouteNode ValidateRouteBlock(ConstIterator_& token, ServerDirective is_cgi);
+
+  // PortMap 생성
+  void GeneratePortMap(Result& result, PortServerList_& port_server_list) const;
 };
 
 #endif  // INCLUDES_VALIDATOR_HPP_

--- a/tests/test_validator.cpp
+++ b/tests/test_validator.cpp
@@ -31,69 +31,90 @@ TEST(ValidatorTest, ServerBlock) {
 
   {
     Validator::Result result = TestValidatorSuccess("ServerBlock/CASE_01");
-    EXPECT_EQ(result.server_map.count("127.0.0.1"), 1);
-    ServerBlock& server_block = result.server_map["127.0.0.1"];
-    RouteMap& route_map = server_block.route_map;
-    HostVector& host_vector = result.host_vector;
+    EXPECT_EQ(result.port_set.size(), 1);
 
-    EXPECT_EQ(host_vector[0].port, 80);
-    EXPECT_EQ(route_map.count("./"), 1) << "ServerBlock/CASE_01";
+    ASSERT_EQ(result.port_set.count(80), 1);
+    ServerGate server_gate = result.port_map[80];
+    ServerMap server_map = server_gate.server_map;
+
+    ASSERT_EQ(server_map.size(), 1);
+    ASSERT_EQ(server_map.count(""), 1);
+    ServerBlock server_block = server_map[""];
+    EXPECT_EQ(server_block.error, "error.html") << "ServerBlock/CASE_01";
   }
 
   {
     Validator::Result result = TestValidatorSuccess("ServerBlock/CASE_02");
-    EXPECT_EQ(result.server_map.count("127.0.0.1:8080"), 1);
-    ServerBlock& server_block = result.server_map["127.0.0.1:8080"];
-    RouteMap& route_map = server_block.route_map;
-    HostVector& host_vector = result.host_vector;
+    EXPECT_EQ(result.port_set.size(), 1);
 
-    EXPECT_EQ(host_vector[0].port, 8080);
+    ASSERT_EQ(result.port_set.count(8080), 1);
+    ServerGate server_gate = result.port_map[8080];
+    ServerMap server_map = server_gate.server_map;
+
+    ASSERT_EQ(server_map.size(), 1);
+    ASSERT_EQ(server_map.count(""), 1);
+    ServerBlock server_block = server_map[""];
+    RouteMap route_map = server_block.route_map;
     EXPECT_EQ(route_map.count("./trash"), 1) << "ServerBlock/CASE_02";
   }
 
   {
     Validator::Result result = TestValidatorSuccess("ServerBlock/CASE_03");
-    EXPECT_EQ(result.server_map.count("127.0.0.1:4242"), 1);
-    ServerBlock& server_block = result.server_map["127.0.0.1:4242"];
-    RouteMap& route_map = server_block.route_map;
-    HostVector& host_vector = result.host_vector;
+    EXPECT_EQ(result.port_set.size(), 1);
+    ASSERT_EQ(result.port_set.count(4242), 1);
+    ServerGate server_gate = result.port_map[4242];
+    ServerMap server_map = server_gate.server_map;
 
-    EXPECT_EQ(host_vector[0].port, 4242);
-    EXPECT_EQ(route_map.count("./hi"), 1) << "ServerBlock/CASE_02";
+    ASSERT_EQ(server_map.size(), 1);
+    ASSERT_EQ(server_map.count(""), 1);
+    ServerBlock server_block = server_map[""];
+    RouteMap route_map = server_block.route_map;
+    EXPECT_EQ(route_map.count("./hi"), 1) << "ServerBlock/CASE_03";
   }
 
   {
     Validator::Result result = TestValidatorSuccess("ServerBlock/CASE_04");
-    EXPECT_EQ(result.server_map.count("127.0.0.1:4242"), 1);
-    ServerBlock& server_block = result.server_map["127.0.0.1:4242"];
-    RouteMap& route_map = server_block.route_map;
-    HostVector& host_vector = result.host_vector;
+    EXPECT_EQ(result.port_set.size(), 1);
 
-    EXPECT_EQ(host_vector[0].port, 4242);
+    ASSERT_EQ(result.port_set.count(4242), 1);
+    ServerGate server_gate = result.port_map[4242];
+    ServerMap server_map = server_gate.server_map;
+
+    ASSERT_EQ(server_map.size(), 1);
+    ASSERT_EQ(server_map.count(""), 1);
+    ServerBlock server_block = server_map[""];
+    RouteMap route_map = server_block.route_map;
     EXPECT_EQ(route_map.count("./return/42"), 1) << "ServerBlock/CASE_04";
   }
 
   TestSyntaxException("ServerBlock/CASE_05");
-
   {
     Validator::Result result = TestValidatorSuccess("ServerBlock/CASE_06");
-    EXPECT_EQ(result.server_map.count("127.0.0.1"), 1);
-    ServerBlock& server_block = result.server_map["127.0.0.1"];
-    RouteMap& route_map = server_block.route_map;
-    HostVector& host_vector = result.host_vector;
+    EXPECT_EQ(result.port_set.size(), 1);
 
-    EXPECT_EQ(host_vector[0].port, 80);
+    ASSERT_EQ(result.port_set.count(80), 1);
+    ServerGate server_gate = result.port_map[80];
+    ServerMap server_map = server_gate.server_map;
+
+    ASSERT_EQ(server_map.size(), 1);
+    ASSERT_EQ(server_map.count(""), 1);
+    ServerBlock server_block = server_map[""];
+    RouteMap route_map = server_block.route_map;
     EXPECT_EQ(route_map.count("./"), 1) << "ServerBlock/CASE_06";
   }
 
   {
     Validator::Result result = TestValidatorSuccess("ServerBlock/CASE_07");
-    EXPECT_EQ(result.server_map.count("127.0.0.1"), 1);
-    ServerBlock& server_block = result.server_map["127.0.0.1"];
-    RouteMap& route_map = server_block.route_map;
-    HostVector& host_vector = result.host_vector;
+    EXPECT_EQ(result.port_set.size(), 1);
 
-    EXPECT_EQ(host_vector[0].port, 80);
+    ASSERT_EQ(result.port_set.count(80), 1);
+    ServerGate server_gate = result.port_map[80];
+    ServerMap server_map = server_gate.server_map;
+
+    ASSERT_EQ(server_map.size(), 1);
+    ASSERT_EQ(server_map.count(""), 1);
+    ServerBlock server_block = server_map[""];
+    RouteMap route_map = server_block.route_map;
     EXPECT_EQ(route_map.count("./"), 1) << "ServerBlock/CASE_07";
   }
 
@@ -104,14 +125,17 @@ TEST(ValidatorTest, ServerBlock) {
 
   {
     Validator::Result result = TestValidatorSuccess("ServerBlock/CASE_12");
-    EXPECT_EQ(result.server_map.count("google.com"), 1);
-    ServerBlock& server_block = result.server_map["google.com"];
-    RouteMap& route_map = server_block.route_map;
-    HostVector& host_vector = result.host_vector;
+    EXPECT_EQ(result.port_set.size(), 1);
 
-    EXPECT_EQ(host_vector[0].port, 80);
-    EXPECT_EQ(host_vector[0].host, "google.com");
+    ASSERT_EQ(result.port_set.count(80), 1);
+    ServerGate server_gate = result.port_map[80];
+    ServerMap server_map = server_gate.server_map;
+
+    ASSERT_EQ(server_map.size(), 1);
+    ASSERT_EQ(server_map.count("google.com"), 1);
+    ServerBlock server_block = server_map["google.com"];
     EXPECT_EQ(server_block.error, "404.html");
+    RouteMap route_map = server_block.route_map;
     EXPECT_EQ(route_map.count("./"), 1) << "ServerBlock/CASE_12";
   }
 
@@ -123,14 +147,19 @@ TEST(ValidatorTest, ServerBlock) {
 
   {
     Validator::Result result = TestValidatorSuccess("ServerBlock/CASE_18");
-    EXPECT_EQ(result.server_map.count("127.0.0.1:8080"), 1);
-    ServerBlock& server_block = result.server_map["127.0.0.1:8080"];
-    RouteMap& route_map = server_block.route_map;
-    HostVector& host_vector = result.host_vector;
 
-    EXPECT_EQ(host_vector[0].port, 8080);
-    EXPECT_EQ(host_vector[0].host, "127.0.0.1");
+    ASSERT_EQ(result.port_map.size(), 1);
+
+    ASSERT_EQ(result.port_map.count(8080), 1);
+    ServerGate server_gate = result.port_map[8080];
+    ServerMap server_map = server_gate.server_map;
+
+    ASSERT_EQ(server_map.size(), 1);
+    ASSERT_EQ(server_map.count(""), 1);
+    ServerBlock server_block = server_map[""];
     EXPECT_EQ(server_block.error, "error.html");
+
+    RouteMap route_map = server_block.route_map;
     EXPECT_EQ(route_map.count("./default"), 1) << "ServerBlock/CASE_18";
   }
 
@@ -139,24 +168,30 @@ TEST(ValidatorTest, ServerBlock) {
 
   {
     Validator::Result result = TestValidatorSuccess("ServerBlock/CASE_21");
-    EXPECT_EQ(result.server_map.count("127.0.0.1"), 1);
-    ServerBlock server_block = result.server_map["127.0.0.1"];
-    RouteMap& route_map = server_block.route_map;
-    HostVector& host_vector = result.host_vector;
+    ASSERT_EQ(result.port_map.size(), 2);
 
-    EXPECT_EQ(host_vector[0].port, 80);
-    EXPECT_EQ(host_vector[0].host, "127.0.0.1");
+    ASSERT_EQ(result.port_map.count(80), 1);
+    ServerGate server_gate = result.port_map[80];
+    ServerMap server_map = server_gate.server_map;
+
+    ASSERT_EQ(server_map.size(), 1);
+    ASSERT_EQ(server_map.count(""), 1);
+    ServerBlock server_block = server_map[""];
     EXPECT_EQ(server_block.error, "error.html");
-    EXPECT_EQ(server_block.route_map.count("./"), 1) << "ServerBlock/CASE_21";
 
-    EXPECT_EQ(result.server_map.count("127.0.0.1:4242"), 1);
-    server_block = result.server_map["127.0.0.1:4242"];
+    EXPECT_EQ(result.port_map.count(4242), 1);
+    server_gate = result.port_map[4242];
+    server_map = server_gate.server_map;
 
-    EXPECT_EQ(host_vector[1].port, 4242);
-    EXPECT_EQ(host_vector[1].host, "127.0.0.1");
+    ASSERT_EQ(server_map.size(), 1);
+    ASSERT_EQ(server_map.count(""), 1);
+    server_block = server_map[""];
     EXPECT_EQ(server_block.error, "error.html");
-    EXPECT_EQ(server_block.route_map.count("./forty_two"), 1)
-        << "ServerBlock/CASE_21";
+
+    PortSet& port_set = result.port_set;
+    ASSERT_EQ(port_set.size(), 2);
+    EXPECT_EQ(port_set.count(80), 1);
+    EXPECT_EQ(port_set.count(4242), 1);
   }
 
   TestSyntaxException("ServerBlock/CASE_22");
@@ -164,69 +199,114 @@ TEST(ValidatorTest, ServerBlock) {
   TestSyntaxException("ServerBlock/CASE_24");
 
   {
-    ServerMap server_map =
-        TestValidatorSuccess("ServerBlock/CASE_25").server_map;
+    Validator::Result result = TestValidatorSuccess("ServerBlock/CASE_25");
+    ASSERT_EQ(result.port_map.size(), 1);
 
-    EXPECT_EQ(server_map.count("blahblah:443"), 1);
-    ServerBlock server_block = server_map["blahblah:443"];
+    ASSERT_EQ(result.port_map.count(443), 1);
+    ServerGate server_gate = result.port_map[443];
+    ServerMap server_map = server_gate.server_map;
+    ASSERT_EQ(server_map.size(), 1);
+    ASSERT_EQ(server_map.count("blahblah"), 1);
+    ServerBlock server_block = server_map["blahblah"];
     EXPECT_EQ(server_block.error, "please.html");
-    EXPECT_EQ(server_block.route_map.count("./"), 1);
+
+    PortSet& port_set = result.port_set;
+    ASSERT_EQ(port_set.size(), 1);
+    EXPECT_EQ(port_set.count(443), 1);
   }
 
   TestSyntaxException("ServerBlock/CASE_26");
-  TestSyntaxException("ServerBlock/CASE_27");
 
   {
-    Validator::Result result = TestValidatorSuccess("ServerBlock/CASE_28");
-    EXPECT_EQ(result.server_map.count("you_are_pro:4242"), 1);
-    ServerBlock server_block = result.server_map["you_are_pro:4242"];
-    RouteMap& route_map = server_block.route_map;
-    HostVector& host_vector = result.host_vector;
+    Validator::Result result = TestValidatorSuccess("ServerBlock/CASE_27");
+    ASSERT_EQ(result.port_map.size(), 1);
 
-    EXPECT_EQ(host_vector[0].port, 4242);
-    EXPECT_EQ(host_vector[0].host, "you_are_pro");
-    EXPECT_EQ(server_block.error, "yes.html");
-    EXPECT_EQ(host_vector.size(), 1);
+    ASSERT_EQ(result.port_map.count(4242), 1);
+    ServerGate server_gate = result.port_map[4242];
+    ServerMap server_map = server_gate.server_map;
+
+    ASSERT_EQ(server_map.size(), 2);
+    ASSERT_EQ(server_map.count(""), 1);
+    ServerBlock server_block = server_map[""];
+    EXPECT_EQ(server_block.error, "error.html");
+
+    ASSERT_EQ(server_map.count("you_are_pro"), 1);
+    server_block = server_map["you_are_pro"];
+    EXPECT_EQ(server_block.error, "error.html");
+
+    PortSet& port_set = result.port_set;
+    ASSERT_EQ(port_set.size(), 1);
+    EXPECT_EQ(port_set.count(4242), 1);
   }
 
-  // TestSyntaxException("ServerBlock/CASE_25");
+  TestSyntaxException("ServerBlock/CASE_28");
 
-  // {
-  //   Validator::Result =
-  //       TestValidatorSuccess("ServerBlock/CASE_26");
+  {
+    Validator::Result result = TestValidatorSuccess("ServerBlock/CASE_29");
+    ASSERT_EQ(result.port_map.size(), 2);
+    ASSERT_EQ(result.port_set.size(), 2);
 
-  //   EXPECT_EQ(server_map.count("127.0.0.1"), 1);
-  //   ServerBlock server_block = server_map["127.0.0.1"];
-  //   EXPECT_EQ(server_block.port, 80);
-  //   EXPECT_EQ(server_block.server_name, "127.0.0.1");
-  //   EXPECT_EQ(server_block.host, "127.0.0.1");
+    ASSERT_EQ(result.port_map.count(8080), 1);
+    ServerGate server_gate = result.port_map[8080];
+    ServerMap server_map = server_gate.server_map;
 
-  //   server_block = server_map["our42vent.42cadet.kr:443"];
-  //   EXPECT_EQ(server_block.port, 443);
-  //   EXPECT_EQ(server_block.server_name, "our42vent.42cadet.kr");
-  //   EXPECT_EQ(server_block.host, "our42vent.42cadet.kr:443");
+    ASSERT_EQ(server_map.size(), 2);
+    ASSERT_EQ(server_map.count(""), 1);
+    ServerBlock server_block = server_map[""];
+    EXPECT_EQ(server_block.error, "energetic.html");
 
-  //   server_block = server_map["127.0.0.1:8080"];
-  //   EXPECT_EQ(server_block.port, 8080);
-  //   EXPECT_EQ(server_block.server_name, "127.0.0.1");
-  //   EXPECT_EQ(server_block.host, "127.0.0.1:8080");
-  // }
+    ASSERT_EQ(server_map.count("ghan"), 1);
+    server_block = server_map["ghan"];
+    EXPECT_EQ(server_block.error, "error.html");
+    EXPECT_EQ(server_gate.default_server.error, "energetic.html");
 
-  // route block 없는 경우
-  // TestSyntaxException("ServerBlock/CASE_26");
+    ASSERT_EQ(result.port_map.count(8081), 1);
+    server_gate = result.port_map[8081];
+    server_map = server_gate.server_map;
+
+    ASSERT_EQ(server_map.count("jiskim"), 1);
+    server_block = server_map["jiskim"];
+    EXPECT_EQ(server_block.error, "error.html");
+
+    PortSet& port_set = result.port_set;
+
+    ASSERT_EQ(port_set.size(), 2);
+    EXPECT_EQ(port_set.count(8080), 1);
+    EXPECT_EQ(port_set.count(8081), 1);
+    EXPECT_EQ(server_gate.default_server.error, "error.html");
+  }
+
+  {
+    Validator::Result result = TestValidatorSuccess("ServerBlock/CASE_30");
+    ASSERT_EQ(result.port_map.size(), 1);
+    ASSERT_EQ(result.port_set.size(), 1);
+    ASSERT_EQ(result.port_map.count(1111), 1);
+    ASSERT_EQ(result.port_set.count(1111), 1);
+    ServerGate server_gate = result.port_map[1111];
+    ServerMap server_map = server_gate.server_map;
+
+    ASSERT_EQ(server_map.size(), 3);
+    ASSERT_EQ(server_map.count("a"), 1);
+    ASSERT_EQ(server_map.count("b"), 1);
+    ASSERT_EQ(server_map.count("z"), 1);
+    EXPECT_EQ(server_gate.default_server.error, "go.html");
+  }
 }
 
 TEST(ValidatorTest, RouteBlock) {
   {
     Validator::Result result = TestValidatorSuccess("RouteBlock/CASE_00");
-    HostVector host_vector = result.host_vector;
-    ServerMap server_map = result.server_map;
+    ASSERT_EQ(result.port_map.size(), 1);
+    ASSERT_EQ(result.port_set.size(), 1);
+    ASSERT_EQ(result.port_map.count(4242), 1);
+    ASSERT_EQ(result.port_set.count(4242), 1);
+    ServerGate server_gate = result.port_map[4242];
+    ServerMap server_map = server_gate.server_map;
 
-    EXPECT_EQ(server_map.count("127.0.0.1:4242"), 1);
-    ServerBlock server_block = server_map["127.0.0.1:4242"];
+    ASSERT_EQ(server_map.size(), 1);
+    ASSERT_EQ(server_map.count(""), 1);
+    ServerBlock server_block = server_map[""];
 
-    EXPECT_EQ(host_vector[0].port, 4242);
-    EXPECT_EQ(host_vector[0].host, "127.0.0.1");
     EXPECT_EQ(server_block.error, "error.html");
     RouteMap route_map = server_block.route_map;
 
@@ -239,14 +319,20 @@ TEST(ValidatorTest, RouteBlock) {
 
   {
     Validator::Result result = TestValidatorSuccess("RouteBlock/CASE_03");
-    HostVector host_vector = result.host_vector;
-    ServerMap server_map = result.server_map;
+    ASSERT_EQ(result.port_map.size(), 1);
+    ASSERT_EQ(result.port_set.size(), 1);
+    ASSERT_EQ(result.port_map.count(80), 1);
+    ASSERT_EQ(result.port_set.count(80), 1);
+    ServerGate server_gate = result.port_map[80];
+    ServerMap server_map = server_gate.server_map;
 
-    EXPECT_EQ(server_map.count("127.0.0.1"), 1);
-    ServerBlock server_block = server_map["127.0.0.1"];
+    ASSERT_EQ(server_map.size(), 1);
+    ASSERT_EQ(server_map.count(""), 1);
+    ServerBlock server_block = server_map[""];
+
     RouteMap route_map = server_block.route_map;
 
-    EXPECT_EQ(route_map.count("./"), 1) << "RouteBlock/CASE_03";
+    ASSERT_EQ(route_map.count("./"), 1) << "RouteBlock/CASE_03";
     RouteBlock route_block = route_map["./"];
     EXPECT_EQ(route_block.root, "./");
     EXPECT_EQ(route_block.index, "");
@@ -258,13 +344,18 @@ TEST(ValidatorTest, RouteBlock) {
 
   {
     Validator::Result result = TestValidatorSuccess("RouteBlock/CASE_04");
-    HostVector host_vector = result.host_vector;
-    ServerMap server_map = result.server_map;
+    ASSERT_EQ(result.port_map.size(), 1);
+    ASSERT_EQ(result.port_set.size(), 1);
+    ASSERT_EQ(result.port_map.count(4242), 1);
+    ASSERT_EQ(result.port_set.count(4242), 1);
+    ServerGate server_gate = result.port_map[4242];
+    ServerMap server_map = server_gate.server_map;
 
-    EXPECT_EQ(server_map.count("127.0.0.1:4242"), 1);
-    ServerBlock server_block = server_map["127.0.0.1:4242"];
+    ASSERT_EQ(server_map.size(), 1);
+    ASSERT_EQ(server_map.count(""), 1);
+    ServerBlock server_block = server_map[""];
     RouteMap route_map = server_block.route_map;
-    EXPECT_EQ(route_map.count(".js"), 1) << "RouteBlock/CASE_04";
+    ASSERT_EQ(route_map.count(".js"), 1) << "RouteBlock/CASE_04";
 
     RouteBlock route_block = route_map[".js"];
     EXPECT_EQ(route_block.root, "./");
@@ -277,13 +368,18 @@ TEST(ValidatorTest, RouteBlock) {
 
   {
     Validator::Result result = TestValidatorSuccess("RouteBlock/CASE_06");
-    HostVector host_vector = result.host_vector;
-    ServerMap server_map = result.server_map;
+    ASSERT_EQ(result.port_map.size(), 1);
+    ASSERT_EQ(result.port_set.size(), 1);
+    ASSERT_EQ(result.port_map.count(4242), 1);
+    ASSERT_EQ(result.port_set.count(4242), 1);
+    ServerGate server_gate = result.port_map[4242];
+    ServerMap server_map = server_gate.server_map;
 
-    EXPECT_EQ(server_map.count("127.0.0.1:4242"), 1);
-    ServerBlock server_block = server_map["127.0.0.1:4242"];
+    ASSERT_EQ(server_map.size(), 1);
+    ASSERT_EQ(server_map.count(""), 1);
+    ServerBlock server_block = server_map[""];
     RouteMap route_map = server_block.route_map;
-    EXPECT_EQ(route_map.count("./everything"), 1) << "RouteBlock/CASE_06";
+    ASSERT_EQ(route_map.count("./everything"), 1) << "RouteBlock/CASE_06";
 
     RouteBlock route_block = route_map["./everything"];
     EXPECT_EQ(route_block.root, "/root");
@@ -293,13 +389,18 @@ TEST(ValidatorTest, RouteBlock) {
 
   {
     Validator::Result result = TestValidatorSuccess("RouteBlock/CASE_07");
-    HostVector host_vector = result.host_vector;
-    ServerMap server_map = result.server_map;
+    ASSERT_EQ(result.port_map.size(), 1);
+    ASSERT_EQ(result.port_set.size(), 1);
+    ASSERT_EQ(result.port_map.count(4242), 1);
+    ASSERT_EQ(result.port_set.count(4242), 1);
+    ServerGate server_gate = result.port_map[4242];
+    ServerMap server_map = server_gate.server_map;
 
-    EXPECT_EQ(server_map.count("127.0.0.1:4242"), 1);
-    ServerBlock server_block = server_map["127.0.0.1:4242"];
+    ASSERT_EQ(server_map.size(), 1);
+    ASSERT_EQ(server_map.count(""), 1);
+    ServerBlock server_block = server_map[""];
     RouteMap route_map = server_block.route_map;
-    EXPECT_EQ(route_map.count("./everything"), 1) << "RouteBlock/CASE_07";
+    ASSERT_EQ(route_map.count("./everything"), 1) << "RouteBlock/CASE_07";
 
     RouteBlock route_block = route_map["./everything"];
     EXPECT_EQ(route_block.methods, GET | POST | DELETE);
@@ -311,13 +412,18 @@ TEST(ValidatorTest, RouteBlock) {
 
   {
     Validator::Result result = TestValidatorSuccess("RouteBlock/CASE_11");
-    HostVector host_vector = result.host_vector;
-    ServerMap server_map = result.server_map;
+    ASSERT_EQ(result.port_map.size(), 1);
+    ASSERT_EQ(result.port_set.size(), 1);
+    ASSERT_EQ(result.port_map.count(4242), 1);
+    ASSERT_EQ(result.port_set.count(4242), 1);
+    ServerGate server_gate = result.port_map[4242];
+    ServerMap server_map = server_gate.server_map;
 
-    EXPECT_EQ(server_map.count("127.0.0.1:4242"), 1);
-    ServerBlock server_block = server_map["127.0.0.1:4242"];
+    ASSERT_EQ(server_map.size(), 1);
+    ASSERT_EQ(server_map.count(""), 1);
+    ServerBlock server_block = server_map[""];
     RouteMap route_map = server_block.route_map;
-    EXPECT_EQ(route_map.count(".php"), 1) << "RouteBlock/CASE_11";
+    ASSERT_EQ(route_map.count(".php"), 1) << "RouteBlock/CASE_11";
 
     RouteBlock route_block = route_map[".php"];
     EXPECT_EQ(route_block.methods, GET | POST);
@@ -327,13 +433,18 @@ TEST(ValidatorTest, RouteBlock) {
 
   {
     Validator::Result result = TestValidatorSuccess("RouteBlock/CASE_13");
-    HostVector host_vector = result.host_vector;
-    ServerMap server_map = result.server_map;
+    ASSERT_EQ(result.port_map.size(), 1);
+    ASSERT_EQ(result.port_set.size(), 1);
+    ASSERT_EQ(result.port_map.count(80), 1);
+    ASSERT_EQ(result.port_set.count(80), 1);
+    ServerGate server_gate = result.port_map[80];
+    ServerMap server_map = server_gate.server_map;
 
-    EXPECT_EQ(server_map.count("127.0.0.1"), 1);
-    ServerBlock server_block = server_map["127.0.0.1"];
+    ASSERT_EQ(server_map.size(), 1);
+    ASSERT_EQ(server_map.count(""), 1);
+    ServerBlock server_block = server_map[""];
     RouteMap route_map = server_block.route_map;
-    EXPECT_EQ(route_map.count("./max"), 1) << "RouteBlock/CASE_13";
+    ASSERT_EQ(route_map.count("./max"), 1) << "RouteBlock/CASE_13";
 
     RouteBlock route_block = route_map["./max"];
     EXPECT_EQ(route_block.methods, POST);
@@ -342,13 +453,18 @@ TEST(ValidatorTest, RouteBlock) {
 
   {
     Validator::Result result = TestValidatorSuccess("RouteBlock/CASE_14");
-    HostVector host_vector = result.host_vector;
-    ServerMap server_map = result.server_map;
+    ASSERT_EQ(result.port_map.size(), 1);
+    ASSERT_EQ(result.port_set.size(), 1);
+    ASSERT_EQ(result.port_map.count(80), 1);
+    ASSERT_EQ(result.port_set.count(80), 1);
+    ServerGate server_gate = result.port_map[80];
+    ServerMap server_map = server_gate.server_map;
 
-    EXPECT_EQ(server_map.count("127.0.0.1"), 1);
-    ServerBlock server_block = server_map["127.0.0.1"];
+    ASSERT_EQ(server_map.size(), 1);
+    ASSERT_EQ(server_map.count(""), 1);
+    ServerBlock server_block = server_map[""];
     RouteMap route_map = server_block.route_map;
-    EXPECT_EQ(route_map.count("./max"), 1) << "RouteBlock/CASE_14";
+    ASSERT_EQ(route_map.count("./max"), 1) << "RouteBlock/CASE_14";
 
     RouteBlock route_block = route_map["./max"];
     EXPECT_EQ(route_block.methods, POST);
@@ -361,26 +477,32 @@ TEST(ValidatorTest, RouteBlock) {
 
   {
     Validator::Result result = TestValidatorSuccess("RouteBlock/CASE_18");
-    HostVector host_vector = result.host_vector;
-    ServerMap server_map = result.server_map;
+    ASSERT_EQ(result.port_map.size(), 1);
+    ASSERT_EQ(result.port_set.size(), 1);
+    ASSERT_EQ(result.port_map.count(5050), 1);
+    ASSERT_EQ(result.port_set.count(5050), 1);
+    ServerGate server_gate = result.port_map[5050];
+    ServerMap server_map = server_gate.server_map;
 
-    EXPECT_EQ(server_map.count("127.0.0.1:5050"), 1);
-    ServerBlock server_block = server_map["127.0.0.1:5050"];
+    ASSERT_EQ(server_map.size(), 1);
+    ASSERT_EQ(server_map.count(""), 1);
+    ServerBlock server_block = server_map[""];
     RouteMap route_map = server_block.route_map;
+    ASSERT_EQ(route_map.size(), 4);
 
-    EXPECT_EQ(route_map.count("./first"), 1);
+    ASSERT_EQ(route_map.count("./first"), 1);
     RouteBlock route_block = route_map["./first"];
     EXPECT_EQ(route_block.methods, GET);
 
-    EXPECT_EQ(route_map.count("./second"), 1);
+    ASSERT_EQ(route_map.count("./second"), 1);
     route_block = route_map["./second"];
     EXPECT_EQ(route_block.methods, POST);
 
-    EXPECT_EQ(route_map.count(".rb"), 1);
+    ASSERT_EQ(route_map.count(".rb"), 1);
     route_block = route_map[".rb"];
     EXPECT_EQ(route_block.param, "rb_param");
 
-    EXPECT_EQ(route_map.count("./third"), 1);
+    ASSERT_EQ(route_map.count("./third"), 1);
     route_block = route_map["./third"];
     EXPECT_EQ(route_block.methods, DELETE);
   }
@@ -389,13 +511,19 @@ TEST(ValidatorTest, RouteBlock) {
 
   {
     Validator::Result result = TestValidatorSuccess("RouteBlock/CASE_20");
-    HostVector host_vector = result.host_vector;
-    ServerMap server_map = result.server_map;
+    ASSERT_EQ(result.port_map.size(), 1);
+    ASSERT_EQ(result.port_set.size(), 1);
+    ASSERT_EQ(result.port_map.count(5252), 1);
+    ASSERT_EQ(result.port_set.count(5252), 1);
+    ServerGate server_gate = result.port_map[5252];
+    ServerMap server_map = server_gate.server_map;
 
-    EXPECT_EQ(server_map.count("127.0.0.1:5252"), 1);
-    ServerBlock server_block = server_map["127.0.0.1:5252"];
+    ASSERT_EQ(server_map.size(), 1);
+    ASSERT_EQ(server_map.count(""), 1);
+    ServerBlock server_block = server_map[""];
     RouteMap route_map = server_block.route_map;
-    EXPECT_EQ(route_map.count(".php"), 1) << "RouteBlock/CASE_20";
+    ASSERT_EQ(route_map.size(), 1);
+    ASSERT_EQ(route_map.count(".php"), 1) << "RouteBlock/CASE_20";
 
     RouteBlock route_block = route_map[".php"];
     EXPECT_EQ(route_block.methods, GET | POST);
@@ -406,39 +534,45 @@ TEST(ValidatorTest, RouteBlock) {
 
   {
     Validator::Result result = TestValidatorSuccess("RouteBlock/CASE_21");
-    HostVector host_vector = result.host_vector;
-    ServerMap server_map = result.server_map;
+    ASSERT_EQ(result.port_map.size(), 1);
+    ASSERT_EQ(result.port_set.size(), 1);
+    ASSERT_EQ(result.port_map.count(17), 1);
+    ASSERT_EQ(result.port_set.count(17), 1);
+    ServerGate server_gate = result.port_map[17];
+    ServerMap server_map = server_gate.server_map;
 
-    EXPECT_EQ(server_map.count("127.0.0.1:17"), 1);
-    ServerBlock server_block = server_map["127.0.0.1:17"];
+    ASSERT_EQ(server_map.size(), 1);
+    ASSERT_EQ(server_map.count(""), 1);
+    ServerBlock server_block = server_map[""];
     RouteMap route_map = server_block.route_map;
+    ASSERT_EQ(route_map.size(), 6);
 
-    EXPECT_EQ(route_map.count("./http_no_port"), 1) << "RouteBlock/CASE_21";
+    ASSERT_EQ(route_map.count("./http_no_port"), 1) << "RouteBlock/CASE_21";
 
     RouteBlock route_block = route_map["./http_no_port"];
     EXPECT_EQ(route_block.redirect_to, "naver.com");
 
-    EXPECT_EQ(route_map.count("./http_port"), 1) << "RouteBlock/CASE_21";
+    ASSERT_EQ(route_map.count("./http_port"), 1) << "RouteBlock/CASE_21";
 
     route_block = route_map["./http_port"];
     EXPECT_EQ(route_block.redirect_to, "naver.com:8080");
 
-    EXPECT_EQ(route_map.count("./http_protoc_no_port"), 1)
+    ASSERT_EQ(route_map.count("./http_protoc_no_port"), 1)
         << "RouteBlock/CASE_21";
     route_block = route_map["./http_protoc_no_port"];
     EXPECT_EQ(route_block.redirect_to, "http://naver.com");
 
-    EXPECT_EQ(route_map.count("./https_protoc_no_port"), 1)
+    ASSERT_EQ(route_map.count("./https_protoc_no_port"), 1)
         << "RouteBlock/CASE_21";
     route_block = route_map["./https_protoc_no_port"];
     EXPECT_EQ(route_block.redirect_to, "https://naver.com");
 
-    EXPECT_EQ(route_map.count("./https_protoc_port"), 1)
+    ASSERT_EQ(route_map.count("./https_protoc_port"), 1)
         << "RouteBlock/CASE_21";
     route_block = route_map["./https_protoc_port"];
     EXPECT_EQ(route_block.redirect_to, "https://naver.com:80");
 
-    EXPECT_EQ(route_map.count("./https_only_port"), 1) << "RouteBlock/CASE_21";
+    ASSERT_EQ(route_map.count("./https_only_port"), 1) << "RouteBlock/CASE_21";
     route_block = route_map["./https_only_port"];
     EXPECT_EQ(route_block.redirect_to, "naver.com:443");
   }


### PR DESCRIPTION
## 개요
- server_name:port 가 같을 경우 에러, 같은 host:port 일 경우 첫번째 서버를 default 로, Host header field 가 있는 요청일 경우 server_name 기반으로 name-based hosting.
- ServerGate 구조체에서 default_server 명시


close #25 

