### PR TITLE
:recycle: refactor : Connection 캡슐화와 keep-alive 여부 확인 #41

### DIFF
--- a/includes/Connection.hpp
+++ b/includes/Connection.hpp
@@ -12,6 +12,16 @@
 
 #define BUFFER_SIZE 4097
 
+#define KEEP_ALIVE 0
+#define CLOSE_1_0 1
+#define CLOSE_LENGTH 2
+#define CLOSE_RECV 3
+#define CLOSE_PARSE 4
+#define CLOSE_ROUTE 5
+#define CLOSE_RESOURCE 6
+#define CLOSE_RESPONSE 7
+#define CLOSE_SEND 8
+
 #include <fcntl.h>
 #include <sys/socket.h>
 #include <unistd.h>
@@ -25,15 +35,19 @@ class Connection {
   Connection(void);
   ~Connection(void);
 
-  void Close(void);
-  void Receive(void);
-  void Send(void);
+  void Reset(void);
+  void HandleRequest(void);
 
   void set_fd(int fd);
+  const int get_status(void) const;
 
  private:
   int fd_;
+  int status_;
   char buffer_[BUFFER_SIZE];
+
+  void Receive(void);
+  void Send(void);
 };
 
 #endif  // INCLUDES_CONNECTION_HPP_

--- a/srcs/Connection.cpp
+++ b/srcs/Connection.cpp
@@ -9,19 +9,33 @@
 
 #include "Connection.hpp"
 
-Connection::Connection(void) : fd_(-1) {}
+Connection::Connection(void) : fd_(-1), status_(KEEP_ALIVE) {
+  memset(buffer_, 0, sizeof(buffer_));
+}
 
 Connection::~Connection(void) { close(fd_); }
 
-void Connection::Close(void) {
-  close(fd_);
+void Connection::Reset(void) {
   fd_ = -1;
+  status_ = KEEP_ALIVE;
+  memset(buffer_, 0, sizeof(buffer_));
 }
 
+void Connection::HandleRequest(void) {
+  Receive();
+  Send();
+}
+
+void Connection::set_fd(int fd) { fd_ = fd; }
+
+const int Connection::get_status(void) const { return status_; }
+
+// SECTION : private
 void Connection::Receive(void) {
   if (recv(fd_, buffer_, BUFFER_SIZE, 0) == -1) {
     std::cerr << "Connection : recv failed for fd " << fd_ << " : "
               << strerror(errno) << '\n';
+    status_ = CLOSE_RECV;
   }
 }
 
@@ -29,7 +43,6 @@ void Connection::Send(void) {
   if (send(fd_, buffer_, BUFFER_SIZE, 0) == -1) {
     std::cerr << "Connection : send failed for fd " << fd_ << " : "
               << strerror(errno) << '\n';
+    status_ = CLOSE_SEND;
   }
 }
-
-void Connection::set_fd(int fd) { fd_ = fd; }

--- a/test_script.sh
+++ b/test_script.sh
@@ -28,15 +28,15 @@ function TEST() {
 	echo "execute client..."
 	sleep .5
 	./build/client "${CONFIG_PATH}s_${2}.config" $3
-	
+
 	if [ $? -eq 0 ]; then
 		echo -e "\n${GREEN}TEST $1 PASSED${RESET}"
 	else
 		echo -e "\n${RED}TEST $1 FAILED${RESET}"
 	fi
-	
+
 	echo -e "==================================================\n"
-	
+
 	sleep 1
 
 	kill $!


### PR DESCRIPTION
## 개요
- `Connection` 내부에서 일어나야하는 작업들을 감싸는 `Connection::HandleRequest` method 추가.
- `Connection::HandleRequest` 안에서 연결을 끊어야 하는 상황 발생 시 `Connection::get_status` 로 상태 전달.

close #41